### PR TITLE
menu overlaps when clicking on collapse

### DIFF
--- a/src/components/layout/navigation.js
+++ b/src/components/layout/navigation.js
@@ -1,42 +1,34 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { Icon, Menu, Layout } from 'antd';
+import { compact, get, join, take } from 'lodash';
 
 import Link from 'umi/link';
 import withRouter from 'umi/withRouter';
+import pathToRegexp from 'path-to-regexp';
 
 const Navigation = props => {
-  const [selectedMenuKeys, setSelectedMenueKeys] = useState(
-    JSON.parse(localStorage.getItem('selectedMenuKeys')) || []
-  );
+  const pathname = get(props, ['location', 'pathname']);
+  const match = pathToRegexp(`/(.*)`).exec(pathname);
+  const pathArr = get(match, 1).split('/');
 
-  useEffect(() => {
-    localStorage.setItem('selectedMenuKeys', JSON.stringify(selectedMenuKeys));
-  });
+  const [openKeys] = useState(pathArr[0] === 'settings' ? ['settings'] : []);
+  const [selectedKeys] = useState([join(take(compact(pathArr), 2), '.')]);
 
   return (
     <Layout.Sider trigger={null} collapsible collapsed={props.collapsed}>
       <div className="logo" style={{ height: 22, margin: '21px 16px', textAlign: 'center' }}>
-        <Link to="/invoices/">
+        <Link to="/invoices">
           <img src={require(`../../assets/logo.svg`)} alt="Upcount" />
         </Link>
       </div>
       <Menu
         theme="dark"
         mode="inline"
-        defaultSelectedKeys={selectedMenuKeys.selectedMenu}
-        defaultOpenKeys={selectedMenuKeys.openSubMenu}
-        onOpenChange={e =>
-          setSelectedMenueKeys({
-            selectedMenu: selectedMenuKeys.selectedMenu,
-            openSubMenu: e,
-          })
-        }
-        onSelect={e =>
-          setSelectedMenueKeys({ selectedMenu: e.key, openSubMenu: selectedMenuKeys.openSubMenu })
-        }
+        defaultOpenKeys={openKeys}
+        defaultSelectedKeys={selectedKeys}
       >
         <Menu.Item key="invoices">
-          <Link to="/invoices/">
+          <Link to="/invoices">
             <div>
               <Icon type="file-text" />
               <span>Invoices</span>
@@ -44,7 +36,7 @@ const Navigation = props => {
           </Link>
         </Menu.Item>
         <Menu.Item key="clients">
-          <Link to="/clients/">
+          <Link to="/clients">
             <div>
               <Icon type="team" />
               <span>Clients</span>
@@ -53,9 +45,6 @@ const Navigation = props => {
         </Menu.Item>
         <Menu.SubMenu
           key="settings"
-          // onOpenChange={e =>
-          //   setSelectedMenueKeys({ openSubMenu: e, openMenu: selectedMenuKeys.openMenu })
-          // }
           title={
             <span>
               <Icon type="setting" />

--- a/src/components/layout/navigation.js
+++ b/src/components/layout/navigation.js
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import { Icon, Menu, Layout } from 'antd';
 import { compact, get, join, take } from 'lodash';
 
@@ -11,8 +10,8 @@ const Navigation = props => {
   const match = pathToRegexp(`/(.*)`).exec(pathname);
   const pathArr = get(match, 1).split('/');
 
-  const [openKeys] = useState(pathArr[0] === 'settings' ? ['settings'] : []);
-  const [selectedKeys] = useState([join(take(compact(pathArr), 2), '.')]);
+  const openKeys = pathArr[0] === 'settings' ? ['settings'] : [];
+  const selectedKeys = [join(take(compact(pathArr), 2), '.')];
 
   return (
     <Layout.Sider trigger={null} collapsible collapsed={props.collapsed}>

--- a/src/components/layout/navigation.js
+++ b/src/components/layout/navigation.js
@@ -22,18 +22,9 @@ class Navigation extends Component {
     });
   }
 
-  onCollapse = collapsed => {
-    this.setState({ collapsed });
-  };
-
   render() {
     return (
-      <Layout.Sider
-        trigger={null}
-        collapsible
-        collapsed={this.props.collapsed}
-        onCollapse={this.onCollapse}
-      >
+      <Layout.Sider trigger={null} collapsible collapsed={this.props.collapsed}>
         <div className="logo" style={{ height: 22, margin: '21px 16px', textAlign: 'center' }}>
           <Link to="/invoices/" onClick={() => this.setState({ selectedMenuKeys: ['invoices'] })}>
             <img src={require(`../../assets/logo.svg`)} alt="Upcount" />

--- a/src/components/layout/navigation.js
+++ b/src/components/layout/navigation.js
@@ -1,6 +1,6 @@
 import { Component } from 'react';
 import { Icon, Menu, Layout } from 'antd';
-import { get, last } from 'lodash';
+import { get } from 'lodash';
 
 import Link from 'umi/link';
 import withRouter from 'umi/withRouter';
@@ -22,48 +22,24 @@ class Navigation extends Component {
     });
   }
 
-  handleMenuClick = e => {
-    const key = last(e.keyPath);
-    switch (key) {
-      case 'logout':
-        this.props.dispatch({ type: 'auth/logout' });
-        break;
-      case 'invoices':
-        this.setState({ openKeys: [], selectedMenuKeys: e.keyPath });
-        break;
-      case 'clients':
-        this.setState({ openKeys: [], selectedMenuKeys: e.keyPath });
-        break;
-      case 'settings':
-        if (e.keyPath.length > 1) {
-          this.setState({ selectedMenuKeys: e.keyPath });
-        } else {
-          const openKeys = this.state.openKeys.length === 0 ? ['settings'] : [];
-          this.setState({ openKeys });
-        }
-        break;
-      default:
-        this.setState({ selectedMenuKeys: e.keyPath });
-    }
+  onCollapse = collapsed => {
+    this.setState({ collapsed });
   };
 
   render() {
-    const { selectedMenuKeys, openKeys } = this.state;
-
     return (
-      <Layout.Sider trigger={null} collapsible collapsed={this.props.collapsed}>
+      <Layout.Sider
+        trigger={null}
+        collapsible
+        collapsed={this.props.collapsed}
+        onCollapse={this.onCollapse}
+      >
         <div className="logo" style={{ height: 22, margin: '21px 16px', textAlign: 'center' }}>
           <Link to="/invoices/" onClick={() => this.setState({ selectedMenuKeys: ['invoices'] })}>
             <img src={require(`../../assets/logo.svg`)} alt="Upcount" />
           </Link>
         </div>
-        <Menu
-          theme="dark"
-          mode="inline"
-          selectedKeys={selectedMenuKeys}
-          openKeys={openKeys}
-          onClick={this.handleMenuClick}
-        >
+        <Menu theme="dark" mode="inline" defaultSelectedKeys={['1']}>
           <Menu.Item key="invoices">
             <Link to="/invoices/">
               <div>
@@ -80,10 +56,8 @@ class Navigation extends Component {
               </div>
             </Link>
           </Menu.Item>
-
           <Menu.SubMenu
             key="settings"
-            onTitleClick={({ key }) => this.handleMenuClick({ keyPath: [key] })}
             title={
               <span>
                 <Icon type="setting" />

--- a/src/components/layout/navigation.js
+++ b/src/components/layout/navigation.js
@@ -1,81 +1,87 @@
-import { Component } from 'react';
+import { useState, useEffect } from 'react';
 import { Icon, Menu, Layout } from 'antd';
-import { get } from 'lodash';
 
 import Link from 'umi/link';
 import withRouter from 'umi/withRouter';
-import pathToRegexp from 'path-to-regexp';
 
-class Navigation extends Component {
-  state = {
-    selectedMenuKeys: [],
-    openKeys: [],
-  };
+const Navigation = props => {
+  const [selectedMenuKeys, setSelectedMenueKeys] = useState(
+    JSON.parse(localStorage.getItem('selectedMenuKeys')) || []
+  );
 
-  componentDidMount() {
-    const pathname = get(this.props, ['location', 'pathname']);
-    const match = pathToRegexp(`/(.*)`).exec(pathname);
-    const pathArr = get(match, 1).split('/');
-    this.setState({
-      selectedMenuKeys: pathArr,
-      openKeys: pathArr[0] === 'settings' ? ['settings'] : [],
-    });
-  }
+  useEffect(() => {
+    localStorage.setItem('selectedMenuKeys', JSON.stringify(selectedMenuKeys));
+  });
 
-  render() {
-    return (
-      <Layout.Sider trigger={null} collapsible collapsed={this.props.collapsed}>
-        <div className="logo" style={{ height: 22, margin: '21px 16px', textAlign: 'center' }}>
-          <Link to="/invoices/" onClick={() => this.setState({ selectedMenuKeys: ['invoices'] })}>
-            <img src={require(`../../assets/logo.svg`)} alt="Upcount" />
+  return (
+    <Layout.Sider trigger={null} collapsible collapsed={props.collapsed}>
+      <div className="logo" style={{ height: 22, margin: '21px 16px', textAlign: 'center' }}>
+        <Link to="/invoices/">
+          <img src={require(`../../assets/logo.svg`)} alt="Upcount" />
+        </Link>
+      </div>
+      <Menu
+        theme="dark"
+        mode="inline"
+        defaultSelectedKeys={selectedMenuKeys.selectedMenu}
+        defaultOpenKeys={selectedMenuKeys.openSubMenu}
+        onOpenChange={e =>
+          setSelectedMenueKeys({
+            selectedMenu: selectedMenuKeys.selectedMenu,
+            openSubMenu: e,
+          })
+        }
+        onSelect={e =>
+          setSelectedMenueKeys({ selectedMenu: e.key, openSubMenu: selectedMenuKeys.openSubMenu })
+        }
+      >
+        <Menu.Item key="invoices">
+          <Link to="/invoices/">
+            <div>
+              <Icon type="file-text" />
+              <span>Invoices</span>
+            </div>
           </Link>
-        </div>
-        <Menu theme="dark" mode="inline" defaultSelectedKeys={['1']}>
-          <Menu.Item key="invoices">
-            <Link to="/invoices/">
-              <div>
-                <Icon type="file-text" />
-                <span>Invoices</span>
-              </div>
+        </Menu.Item>
+        <Menu.Item key="clients">
+          <Link to="/clients/">
+            <div>
+              <Icon type="team" />
+              <span>Clients</span>
+            </div>
+          </Link>
+        </Menu.Item>
+        <Menu.SubMenu
+          key="settings"
+          // onOpenChange={e =>
+          //   setSelectedMenueKeys({ openSubMenu: e, openMenu: selectedMenuKeys.openMenu })
+          // }
+          title={
+            <span>
+              <Icon type="setting" />
+              <span>Settings</span>
+            </span>
+          }
+        >
+          <Menu.Item key="settings.organization">
+            <Link to="/settings/organization">
+              <Icon type="contacts" /> Organization
             </Link>
           </Menu.Item>
-          <Menu.Item key="clients">
-            <Link to="/clients/">
-              <div>
-                <Icon type="team" />
-                <span>Clients</span>
-              </div>
+          <Menu.Item key="settings.invoice">
+            <Link to="/settings/invoice">
+              <Icon type="contacts" /> Invoice
             </Link>
           </Menu.Item>
-          <Menu.SubMenu
-            key="settings"
-            title={
-              <span>
-                <Icon type="setting" />
-                <span>Settings</span>
-              </span>
-            }
-          >
-            <Menu.Item key="organization">
-              <Link to="/settings/organization">
-                <Icon type="contacts" /> Organization
-              </Link>
-            </Menu.Item>
-            <Menu.Item key="invoice">
-              <Link to="/settings/invoice">
-                <Icon type="contacts" /> Invoice
-              </Link>
-            </Menu.Item>
-            <Menu.Item key="tax-rates">
-              <Link to="/settings/tax-rates">
-                <Icon type="calculator" /> Tax rates
-              </Link>
-            </Menu.Item>
-          </Menu.SubMenu>
-        </Menu>
-      </Layout.Sider>
-    );
-  }
-}
+          <Menu.Item key="settings.tax-rates">
+            <Link to="/settings/tax-rates">
+              <Icon type="calculator" /> Tax rates
+            </Link>
+          </Menu.Item>
+        </Menu.SubMenu>
+      </Menu>
+    </Layout.Sider>
+  );
+};
 
 export default withRouter(Navigation);

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -15,7 +15,6 @@ class Index extends Component {
   }
 
   setOrganization = id => {
-    localStorage.removeItem('selectedMenuKeys'); // removing last persistans for Navigation
     localStorage.setItem('organization', id);
     router.push({
       pathname: '/invoices',

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -15,6 +15,7 @@ class Index extends Component {
   }
 
   setOrganization = id => {
+    localStorage.removeItem('selectedMenuKeys'); // removing last persistans for Navigation
     localStorage.setItem('organization', id);
     router.push({
       pathname: '/invoices',


### PR DESCRIPTION
Replaced the menuhandleclick function with a collapse state.
The menu no longer overlaps and is displayed with a hover

closes #37