### PR TITLE
 navbar items hide

### DIFF
--- a/src/components/layout/navigation.js
+++ b/src/components/layout/navigation.js
@@ -31,7 +31,9 @@ const Navigation = props => {
           <Link to="/invoices">
             <div>
               <Icon type="file-text" />
-              <Trans>Invoices</Trans>
+              <span>
+                <Trans>Invoices</Trans>
+              </span>
             </div>
           </Link>
         </Menu.Item>
@@ -39,17 +41,21 @@ const Navigation = props => {
           <Link to="/clients">
             <div>
               <Icon type="team" />
-              <Trans>Clients</Trans>
+              <span>
+                <Trans>Clients</Trans>
+              </span>
             </div>
           </Link>
         </Menu.Item>
         <Menu.SubMenu
           key="settings"
           title={
-            <span>
+            <div>
               <Icon type="setting" />
-              <Trans>Settings</Trans>
-            </span>
+              <span>
+                <Trans>Settings</Trans>
+              </span>
+            </div>
           }
         >
           <Menu.Item key="settings.organization">

--- a/src/pages/settings/organization/_layout.js
+++ b/src/pages/settings/organization/_layout.js
@@ -46,10 +46,12 @@ class Organization extends Component {
                   label={<Trans>Registration number</Trans>}
                 />
                 <Row gutter={16}>
-                  <Col span={12}>
+                  <Col>
                     <Field name="bank" component={AInput} label={<Trans>Bank name</Trans>} />
                   </Col>
-                  <Col span={12}>
+                </Row>
+                <Row gutter={16}>
+                  <Col>
                     <Field name="iban" component={AInput} label={<Trans>IBAN</Trans>} />
                   </Col>
                 </Row>


### PR DESCRIPTION
close #43 

- Hiding text from Navbar items when collapsing the navbar
- Settings > Organization > Bank name and IBAN each in own row for more space


