### PR TITLE
Make invoice notes and registration number optional in PDF

### DIFF
--- a/src/components/invoices/pdf.tsx
+++ b/src/components/invoices/pdf.tsx
@@ -283,17 +283,21 @@ const InvoicePDF = ({
             </View>
           </View>
 
-          <View style={styles.row}>
-            <View style={styles.column}>
-              <Text style={styles.notes}>Thank you for your business!</Text>
+          {invoice.customerNotes && (
+            <View style={styles.row}>
+              <View style={styles.column}>
+                <Text style={styles.notes}>{invoice.customerNotes}</Text>
+              </View>
             </View>
-          </View>
+          )}
 
           <View style={styles.footer}>
             <Text style={[styles.text]}>
               {organization.bank_name} {organization.iban}
             </Text>
-            <Text style={[styles.text, { textAlign: "center" }]}>Reg. nr {organization.registration_number}</Text>
+            {organization.registration_number && (
+              <Text style={[styles.text, { textAlign: "center" }]}>Reg. nr {organization.registration_number}</Text>
+            )}
             <Text style={[styles.text, { textAlign: "right" }]}>VATIN {organization.vatin}</Text>
           </View>
         </Page>


### PR DESCRIPTION
## Summary
- Replace hardcoded "Thank you for your business\!" with dynamic `customerNotes` field from invoice data
- Hide notes section completely when `customerNotes` is empty to prevent empty space
- Hide registration number in footer when not defined in organization settings

## Changes
- Modified `src/components/invoices/pdf.tsx` to use conditional rendering for both elements
- Notes now use `invoice.customerNotes` instead of hardcoded text
- Registration number only shows when `organization.registration_number` exists

Fixes #154

🤖 Generated with [Claude Code](https://claude.ai/code)