### PR TITLE
Add client delete functionality

### DIFF
--- a/src/atoms.tsx
+++ b/src/atoms.tsx
@@ -109,6 +109,20 @@ export const clientAtom = atom(
   }
 );
 
+// Delete client
+export const deleteClientAtom = atom(null, async (get, set, clientId: string) => {
+  const response = await sqlite.execute("DELETE FROM clients WHERE id = $1", [clientId]);
+  
+  if (response["rowsAffected"] == 1) {
+    // Remove client from the list
+    const clients: any = reject(get(clientsAtom), (obj: any) => isEqual(obj.id, clientId));
+    set(clientsAtom, clients);
+    message.success(t`Client deleted`);
+  } else {
+    message.error(t`Client deletion failed`);
+  }
+});
+
 // Invoices
 export const invoicesAtom = atom([]);
 export const setInvoicesAtom = atom(null, async (get, set) => {
@@ -349,7 +363,7 @@ export const organizationAtom = atom(
 // Delete organization
 export const deleteOrganizationAtom = atom(null, async (get, set) => {
   const organizationId = get(organizationIdAtom);
-  await sqlite.select("DELETE FROM organizations WHERE id = $1", [organizationId]);
+  await sqlite.execute("DELETE FROM organizations WHERE id = $1", [organizationId]);
 
   // TODO: needs some validation that DELETE was successful
   const organizations: any = reject(get(organizationsAtom), (obj: any) => isEqual(obj.id, organizationId));

--- a/src/components/clients/form.tsx
+++ b/src/components/clients/form.tsx
@@ -1,12 +1,13 @@
 import { useEffect } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
-import { Form, Input, Modal, Select } from "antd";
-import { atom, useAtom } from "jotai";
+import { Form, Input, Modal, Select, Button, Popconfirm } from "antd";
+import { atom, useAtom, useSetAtom } from "jotai";
 import { t, Trans } from "@lingui/macro";
+import { DeleteOutlined } from "@ant-design/icons";
 import isEmpty from "lodash/isEmpty";
 import get from "lodash/get";
 
-import { clientIdAtom, clientAtom } from "src/atoms";
+import { clientIdAtom, clientAtom, deleteClientAtom } from "src/atoms";
 
 const submittingAtom = atom(false);
 
@@ -18,6 +19,7 @@ const ClientForm = () => {
   const [clientId, setClientId] = useAtom(clientIdAtom);
   const [client, setClient] = useAtom(clientAtom);
   const [submitting, setSubmitting] = useAtom(submittingAtom);
+  const deleteClient = useSetAtom(deleteClientAtom);
 
   const handleSubmit = async (values: any) => {
     setSubmitting(true);
@@ -26,6 +28,17 @@ const ClientForm = () => {
     navigate(location.pathname, { state: { clientModal: false } });
     form.resetFields();
     setSubmitting(false);
+  };
+
+  const handleDelete = async () => {
+    if (clientId) {
+      setSubmitting(true);
+      await deleteClient(clientId);
+      setClientId(null);
+      navigate(location.pathname, { state: { clientModal: false } });
+      form.resetFields();
+      setSubmitting(false);
+    }
   };
 
   useEffect(() => {
@@ -51,6 +64,44 @@ const ClientForm = () => {
         form.resetFields();
         navigate(location.pathname, { state: { clientModal: false } });
       }}
+      footer={[
+        <div key="footer" style={{ display: 'flex', justifyContent: 'space-between', width: '100%' }}>
+          <div>
+            {clientId && (
+              <Popconfirm
+                title={<Trans>Are you sure you want to delete this client?</Trans>}
+                onConfirm={handleDelete}
+                okText={<Trans>Yes</Trans>}
+                cancelText={<Trans>No</Trans>}
+                placement="topRight"
+              >
+                <Button danger icon={<DeleteOutlined />} loading={submitting}>
+                  <Trans>Delete</Trans>
+                </Button>
+              </Popconfirm>
+            )}
+          </div>
+          <div>
+            <Button
+              onClick={() => {
+                setClientId(null);
+                form.resetFields();
+                navigate(location.pathname, { state: { clientModal: false } });
+              }}
+              style={{ marginRight: 8 }}
+            >
+              <Trans>Cancel</Trans>
+            </Button>
+            <Button
+              type="primary"
+              loading={submitting}
+              onClick={() => form.submit()}
+            >
+              <Trans>Save</Trans>
+            </Button>
+          </div>
+        </div>
+      ]}
       forceRender={true}
     >
       {(!clientId || !isEmpty(client)) && (


### PR DESCRIPTION
## Summary
- Add ability to delete clients from the client edit modal
- Include confirmation dialog to prevent accidental deletions
- Position delete button safely on the left side of modal footer

## Changes
- Added `deleteClientAtom` in `src/atoms.tsx` for handling client deletion with proper error handling
- Modified `src/components/clients/form.tsx` to include delete button with confirmation
- Fixed organization delete atom to use `execute` instead of `select` for consistency

## Implementation Details
- Delete button only appears when editing existing clients (not when creating new ones)
- Uses Ant Design's Popconfirm component for confirmation dialog
- Button is styled with danger variant and delete icon for clear indication
- Positioned on left side of footer to separate from primary actions (Cancel/Save)

Fixes #141

🤖 Generated with [Claude Code](https://claude.ai/code)