### PR TITLE
Fix AppImage crash on Ubuntu 26.04 (libglvnd 1.7 EGL rejection)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
             args: "--target aarch64-apple-darwin"
           - platform: "macos-latest" # for Intel based macs.
             args: "--target x86_64-apple-darwin"
-          - platform: "ubuntu-22.04"
+          - platform: "ubuntu-24.04"
             args: ""
 
     runs-on: ${{ matrix.settings.platform }}
@@ -26,11 +26,11 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: install dependencies (ubuntu only)
-        if: matrix.settings.platform == 'ubuntu-22.04'
+        if: matrix.settings.platform == 'ubuntu-24.04'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.0-dev libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
-        # webkitgtk 4.0 is for Tauri v1 - webkitgtk 4.1 is for Tauri v2.
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+        # webkitgtk 4.1 is for Tauri v2.
 
       - name: setup node
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary

- Bump Linux build runner from `ubuntu-22.04` to `ubuntu-24.04` so the AppImage bundles a WebKitGTK that uses the modern `eglGetPlatformDisplay` API.
- Drop obsolete `libwebkit2gtk-4.0-dev` (Tauri v1 leftover).

## Problem

Reported on Ubuntu 26.04: launching the `v2.0.0-beta.23` AppImage immediately aborts in `WebKitWebProcess`:

```
Initializing database at: sqlite:///home/.../sqlite.db
Database initialized successfully
Could not create default EGL display: EGL_BAD_PARAMETER. Aborting...
[SIGABRT]
```

The AppImage built on `ubuntu-22.04` bundles WebKitGTK 2.36/2.40, which calls the deprecated `eglGetDisplay(EGL_DEFAULT_DISPLAY)`. libglvnd 1.7 (shipped on Ubuntu 26.04) rejects that call with `EGL_BAD_PARAMETER`. Same root cause will surface on any distro shipping libglvnd >= 1.7.

No env-var workaround helps (`WEBKIT_DISABLE_DMABUF_RENDERER`, `WEBKIT_DISABLE_COMPOSITING_MODE`, `LIBGL_ALWAYS_SOFTWARE`, `GDK_BACKEND=x11`, `GDK_BACKEND=wayland` all crash identically). The system EGL is healthy (`eglinfo` works); only the AppImage's bundled WebKit is incompatible.

## Fix

`ubuntu-24.04` ships `libwebkit2gtk-4.1` >= 2.44 which uses `eglGetPlatformDisplay`. Verified by building locally on the affected Ubuntu 26.04 system (which ships WebKitGTK 2.52.0) — the new AppImage launches cleanly where the previous release immediately aborted.

## Test plan

- [x] Reproduce crash with the existing `v2.0.0-beta.23` AppImage on Ubuntu 26.04
- [x] Build AppImage locally on Ubuntu 26.04 with the bumped toolchain — confirmed launches without the EGL error
- [ ] Verify CI build succeeds on `ubuntu-24.04` after merge
- [ ] Smoke-test the resulting release AppImage on Ubuntu 22.04, 24.04, and 26.04

🤖 Generated with [Claude Code](https://claude.com/claude-code)